### PR TITLE
Added Linux commands to create ami

### DIFF
--- a/Day10/README.md
+++ b/Day10/README.md
@@ -61,4 +61,14 @@ Launch a new console for the settings to take effect.
 
 -	$ packer.exe inspect --var-file packer-vars.json packer.json
 
-
+  # Linux Commands
+- Download packer for linux from packer.io
+- clone github repo https://github.com/saikiranpi/packer.git
+- cd packer
+- edit packer-vars.json file and add your access key and secret access key, vpc-id and subnetid
+- Check for the ami (make sure you are selecting ubuntu and us-east-1 region ami id)
+- ensure auto assign public ip is enable for the subnet
+- Run below commands
+  sudo packer validate --var-file packer-vars.json packer.json
+  sudo packer inspect --var-file packer-vars.json packer.json
+  sudo packer build --var-file packer-vars.json packer.json


### PR DESCRIPTION
Added essential Linux commands and documented an issue encountered during AMI creation.

Issue: The subnet ID used had auto-assign public IP disabled, resulting in only private IP assignment and packer uses SSH attempts using the private IP.

Resolution: Enabled auto-assign public IP for the subnet and successfully ran the Packer build command.